### PR TITLE
Rename table types to include 'Table' prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.8.2
+
+### Patch Changes
+
+- Rename table types to include 'Table' prefix
+
 ## 1.8.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "simple-react-ui-kit",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "description": "A lightweight and flexible UI framework for building responsive React applications with customizable components.",
     "repository": "https://github.com/miksrv/simple-react-ui-kit.git",
     "keywords": [

--- a/src/components/table/Table.test.tsx
+++ b/src/components/table/Table.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 
 import { Table } from './Table'
-import { ColumnProps } from './types'
+import { TableColumnProps } from './types'
 
 import styles from './styles.module.sass'
 
@@ -13,7 +13,7 @@ interface TestData {
     age: number
 }
 
-const columns: Array<ColumnProps<TestData>> = [
+const columns: Array<TableColumnProps<TestData>> = [
     { header: 'ID', accessor: 'id', isSortable: true },
     { header: 'Name', accessor: 'name', isSortable: true },
     { header: 'Age', accessor: 'age', isSortable: true }
@@ -107,7 +107,7 @@ describe('Table Component', () => {
     })
 
     it('applies formatter function to the cell value', () => {
-        const columnsWithFormatter: Array<ColumnProps<TestData>> = [
+        const columnsWithFormatter: Array<TableColumnProps<TestData>> = [
             { header: 'ID', accessor: 'id', isSortable: true },
             { header: 'Name', accessor: 'name', formatter: (value) => `Name: ${value}`, isSortable: true },
             { header: 'Age', accessor: 'age', isSortable: true }
@@ -126,7 +126,7 @@ describe('Table Component', () => {
     })
 
     it('applies background color function to the cell', () => {
-        const columnsWithBackground: Array<ColumnProps<TestData>> = [
+        const columnsWithBackground: Array<TableColumnProps<TestData>> = [
             { header: 'ID', accessor: 'id', isSortable: true },
             {
                 header: 'Name',
@@ -152,7 +152,7 @@ describe('Table Component', () => {
     })
 
     it('does not sort when the column is not sortable', () => {
-        const columnsWithNonSortable: Array<ColumnProps<TestData>> = [
+        const columnsWithNonSortable: Array<TableColumnProps<TestData>> = [
             { header: 'ID', accessor: 'id', isSortable: true },
             { header: 'Name', accessor: 'name', isSortable: false },
             { header: 'Age', accessor: 'age', isSortable: true }
@@ -175,7 +175,7 @@ describe('Table Component', () => {
     })
 
     it('displays skeletons when loading is true', () => {
-        const columns: Array<ColumnProps<TestData>> = [
+        const columns: Array<TableColumnProps<TestData>> = [
             { header: 'ID', accessor: 'id', isSortable: true },
             { header: 'Name', accessor: 'name', isSortable: true },
             { header: 'Age', accessor: 'age', isSortable: true }
@@ -195,7 +195,7 @@ describe('Table Component', () => {
     })
 
     it('displays no data message when there is no data', () => {
-        const columns: Array<ColumnProps<TestData>> = [
+        const columns: Array<TableColumnProps<TestData>> = [
             { header: 'ID', accessor: 'id', isSortable: true },
             { header: 'Name', accessor: 'name', isSortable: true },
             { header: 'Age', accessor: 'age', isSortable: true }
@@ -213,7 +213,7 @@ describe('Table Component', () => {
     })
 
     it('renders columns based on the hidden property', () => {
-        const columnsWithHidden: Array<ColumnProps<TestData>> = [
+        const columnsWithHidden: Array<TableColumnProps<TestData>> = [
             { header: 'ID', accessor: 'id', isSortable: true },
             { header: 'Name', accessor: 'name', isSortable: true, hidden: true },
             { header: 'Age', accessor: 'age', isSortable: true }
@@ -364,7 +364,7 @@ describe('Table Component', () => {
     })
 
     it('renders column with className applied to td', () => {
-        const columnsWithClass: Array<ColumnProps<TestData>> = [
+        const columnsWithClass: Array<TableColumnProps<TestData>> = [
             { header: 'ID', accessor: 'id', className: 'id-cell' },
             { header: 'Name', accessor: 'name' },
             { header: 'Age', accessor: 'age' }
@@ -424,7 +424,7 @@ describe('Table Component', () => {
     })
 
     it('formats cell value with full row data access via formatter', () => {
-        const columnsWithRowAccess: Array<ColumnProps<TestData>> = [
+        const columnsWithRowAccess: Array<TableColumnProps<TestData>> = [
             { header: 'ID', accessor: 'id' },
             {
                 header: 'Summary',
@@ -444,7 +444,7 @@ describe('Table Component', () => {
 
     it('calls onChangeSort with asc direction on first click', () => {
         const onChangeSort = jest.fn()
-        const columnsWithExternalSort: Array<ColumnProps<TestData>> = [
+        const columnsWithExternalSort: Array<TableColumnProps<TestData>> = [
             { header: 'ID', accessor: 'id' },
             { header: 'Name', accessor: 'name', onChangeSort },
             { header: 'Age', accessor: 'age' }
@@ -464,7 +464,7 @@ describe('Table Component', () => {
 
     it('calls onChangeSort with desc direction on second click', () => {
         const onChangeSort = jest.fn()
-        const columnsWithExternalSort: Array<ColumnProps<TestData>> = [
+        const columnsWithExternalSort: Array<TableColumnProps<TestData>> = [
             { header: 'ID', accessor: 'id' },
             { header: 'Name', accessor: 'name', onChangeSort },
             { header: 'Age', accessor: 'age' }
@@ -485,7 +485,7 @@ describe('Table Component', () => {
 
     it('does not sort data locally when column has onChangeSort', () => {
         const onChangeSort = jest.fn()
-        const columnsWithExternalSort: Array<ColumnProps<TestData>> = [
+        const columnsWithExternalSort: Array<TableColumnProps<TestData>> = [
             { header: 'ID', accessor: 'id' },
             { header: 'Name', accessor: 'name', onChangeSort },
             { header: 'Age', accessor: 'age' }
@@ -509,7 +509,7 @@ describe('Table Component', () => {
 
     it('shows sort icon for external sort column when sort prop matches', () => {
         const onChangeSort = jest.fn()
-        const columnsWithExternalSort: Array<ColumnProps<TestData>> = [
+        const columnsWithExternalSort: Array<TableColumnProps<TestData>> = [
             { header: 'ID', accessor: 'id' },
             { header: 'Name', accessor: 'name', onChangeSort },
             { header: 'Age', accessor: 'age' }
@@ -529,7 +529,7 @@ describe('Table Component', () => {
 
     it('does not show sort icon for external sort column when sort prop does not match', () => {
         const onChangeSort = jest.fn()
-        const columnsWithExternalSort: Array<ColumnProps<TestData>> = [
+        const columnsWithExternalSort: Array<TableColumnProps<TestData>> = [
             { header: 'ID', accessor: 'id' },
             { header: 'Name', accessor: 'name', onChangeSort },
             { header: 'Age', accessor: 'age' }

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -4,7 +4,7 @@ import { cn } from '../../utils'
 import { Icon } from '../icon'
 import { Skeleton } from '../skeleton'
 
-import { ColumnProps, SortConfig, TableProps } from './types'
+import { TableColumnProps, TableProps, TableSortConfig } from './types'
 
 import styles from './styles.module.sass'
 
@@ -22,7 +22,7 @@ export const Table = <T,>({
     verticalBorder,
     sort
 }: TableProps<T>) => {
-    const [sortConfig, setSortConfig] = useState<SortConfig<T> | null>(defaultSort ?? null)
+    const [sortConfig, setSortConfig] = useState<TableSortConfig<T> | null>(defaultSort ?? null)
 
     const visibleColumns = columns?.filter(({ hidden }) => !hidden)
 
@@ -43,7 +43,7 @@ export const Table = <T,>({
     }, [data, sortConfig])
 
     const handleSort = useCallback(
-        (column: ColumnProps<T>) => {
+        (column: TableColumnProps<T>) => {
             if (column.onChangeSort) {
                 let direction: 'asc' | 'desc' = 'asc'
                 if (sort && sort.key === column.accessor && sort.direction === 'asc') {
@@ -67,7 +67,7 @@ export const Table = <T,>({
         [sort, sortConfig]
     )
 
-    const getSortIcon = (column: ColumnProps<T>) => {
+    const getSortIcon = (column: TableColumnProps<T>) => {
         if (column.onChangeSort) {
             if (sort?.key !== column.accessor) {
                 return ''

--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -1,2 +1,2 @@
 export { Table } from './Table'
-export { type ColumnProps, type TableProps } from './types'
+export { type TableColumnProps, type TableProps, type TableSortConfig } from './types'

--- a/src/components/table/types.ts
+++ b/src/components/table/types.ts
@@ -5,7 +5,7 @@ import { ElementSizeType } from '../../types'
 /**
  * Column properties for table component
  */
-export interface ColumnProps<T> {
+export interface TableColumnProps<T> {
     /** Header content for the column */
     header: string | React.ReactNode
     /** Accessor key to map data for the column */
@@ -22,7 +22,7 @@ export interface ColumnProps<T> {
     formatter?: (value: T[keyof T], row: T[], index: number) => React.ReactNode
     /** External sort callback. When provided, clicking this column header fires the callback
      *  instead of sorting data locally. Use together with TableProps.sort to show the active indicator. */
-    onChangeSort?: (sort: SortConfig<T>) => void
+    onChangeSort?: (sort: TableSortConfig<T>) => void
 }
 
 /**
@@ -34,7 +34,7 @@ export interface TableProps<T> {
     /** Size (height) of the table rows */
     size?: ElementSizeType
     /** Default sorting configuration for the table */
-    defaultSort?: SortConfig<T>
+    defaultSort?: TableSortConfig<T>
     /** Additional class names for custom styling */
     className?: string
     /** Caption to display when there is no data */
@@ -47,7 +47,7 @@ export interface TableProps<T> {
      * that the height of the container will change dynamically up to the maximum value */
     maxHeight?: number | null
     /** Column configuration for the table */
-    columns?: Array<ColumnProps<T>>
+    columns?: Array<TableColumnProps<T>>
     /** Whether the table is in loading state (displays skeletons) */
     loading?: boolean
     /** Whether the table header is sticky when scrolling */
@@ -56,13 +56,13 @@ export interface TableProps<T> {
     verticalBorder?: boolean
     /** Controlled sort state for external (server-side) sorting.
      *  Pass this together with column.onChangeSort to display the active sort indicator. */
-    sort?: SortConfig<T>
+    sort?: TableSortConfig<T>
 }
 
 /**
  * Sorting configuration
  */
-export interface SortConfig<T> {
+export interface TableSortConfig<T> {
     /** Key to sort by */
     key: keyof T
     /** Sort direction */

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export { Progress, type ProgressProps } from './components/progress'
 export { type OptionsListProps, Select, type SelectOptionType, type SelectProps } from './components/select'
 export { Skeleton, type SkeletonProps } from './components/skeleton'
 export { Spinner, type SpinnerProps } from './components/spinner'
-export { type ColumnProps, Table, type TableProps } from './components/table'
+export { Table, type TableColumnProps, type TableProps, type TableSortConfig } from './components/table'
 export { TextArea, type TextAreaProps } from './components/textarea'
 
 // Tools

--- a/storybook/stories/Table.stories.tsx
+++ b/storybook/stories/Table.stories.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react'
 
 import type { Meta, StoryFn, StoryObj } from '@storybook/react'
 
-import { type ColumnProps, Table, type TableProps } from '../../src'
-import { SortConfig } from '../../src/components/table/types'
+import { Table, type TableColumnProps, type TableProps } from '../../src'
+import { TableSortConfig } from '../../src/components/table/types'
 
 type Row = {
     id: number
@@ -22,7 +22,7 @@ const sampleData: Row[] = [
     { id: 6, name: 'Frank Miller', status: 'inactive', role: 'Viewer', score: 33 }
 ]
 
-const baseColumns: Array<ColumnProps<Row>> = [
+const baseColumns: Array<TableColumnProps<Row>> = [
     { header: 'ID', accessor: 'id', isSortable: true },
     { header: 'Name', accessor: 'name', isSortable: true },
     { header: 'Role', accessor: 'role' },
@@ -38,13 +38,13 @@ const meta: Meta<TableProps<Row>> = {
         docs: {
             description: {
                 component:
-                    'A generic typed data table (`Table<T>`) that supports client-side sorting, loading skeletons, sticky header, vertical borders, custom cell formatters, and background colour functions. Define columns with the `ColumnProps<T>` interface and pass `data` as an array of `T`.'
+                    'A generic typed data table (`Table<T>`) that supports client-side sorting, loading skeletons, sticky header, vertical borders, custom cell formatters, and background colour functions. Define columns with the `TableColumnProps<T>` interface and pass `data` as an array of `T`.'
             }
         }
     },
     argTypes: {
         data: { control: false, description: 'Array of row data objects' },
-        columns: { control: false, description: 'Column configuration array (`ColumnProps<T>[]`)' },
+        columns: { control: false, description: 'Column configuration array (`TableColumnProps<T>[]`)' },
         size: {
             control: 'inline-radio',
             options: ['small', 'medium', 'large'],
@@ -249,7 +249,7 @@ export const WithFormatter: Story = {
                 isSortable: true,
                 formatter: (value) => <strong>{String(value)}</strong>
             }
-        ] as Array<ColumnProps<Row>>
+        ] as Array<TableColumnProps<Row>>
     },
     parameters: {
         docs: {
@@ -284,7 +284,7 @@ export const WithBackground: Story = {
                     return '#fee2e2'
                 }
             }
-        ] as Array<ColumnProps<Row>>
+        ] as Array<TableColumnProps<Row>>
     },
     parameters: {
         docs: {
@@ -296,18 +296,18 @@ export const WithBackground: Story = {
 }
 
 const WithExternalSortTemplate: StoryFn<TableProps<Row>> = () => {
-    const [sort, setSort] = useState<SortConfig<Row> | undefined>(undefined)
+    const [sort, setSort] = useState<TableSortConfig<Row> | undefined>(undefined)
 
-    const columns: Array<ColumnProps<Row>> = [
+    const columns: Array<TableColumnProps<Row>> = [
         {
             header: 'Name',
             accessor: 'name',
-            onChangeSort: (newSort) => setSort(newSort as SortConfig<Row>)
+            onChangeSort: (newSort) => setSort(newSort as TableSortConfig<Row>)
         },
         {
             header: 'Score',
             accessor: 'score',
-            onChangeSort: (newSort) => setSort(newSort as SortConfig<Row>)
+            onChangeSort: (newSort) => setSort(newSort as TableSortConfig<Row>)
         },
         { header: 'Role', accessor: 'role' }
     ]


### PR DESCRIPTION
Rename ColumnProps -> TableColumnProps and SortConfig -> TableSortConfig across the table component API and usages. Updated types, imports, and exports in src/components/table (types, Table, index), updated public exports in src/index.ts, and adjusted tests and Storybook stories to use the new type names. This clarifies naming and avoids generic type name collisions while keeping behavior unchanged.