### PR TITLE
Add per-group size CSS vars and update components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.8.3
+
+### Patch Changes
+
+- Add per-group size CSS vars and update components
+
 ## 1.8.2
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -1183,6 +1183,14 @@ All components are themed via CSS custom properties defined on `:root`. Override
 
 #### Available CSS Variables
 
+- **Element Heights (`size` prop):**
+    - `--size-small`: Height for `small` size variant (default: `28px`). Applied to all sized components as a global fallback.
+    - `--size-medium`: Height for `medium` size variant (default: `34px`). Applied to all sized components as a global fallback.
+    - `--size-large`: Height for `large` size variant (default: `38px`). Applied to all sized components as a global fallback.
+    - `--size-control-small` / `--size-control-medium` / `--size-control-large`: Optional per-group overrides for form controls (`Input`, `Select`, `Button`, `TextArea`). Fall back to `--size-*` if not set.
+    - `--size-badge-small` / `--size-badge-medium` / `--size-badge-large`: Optional per-group overrides for `Badge`. Fall back to `--size-*` if not set.
+    - `--size-table-small` / `--size-table-medium` / `--size-table-large`: Optional per-group overrides for `Table` row heights. Fall back to `--size-*` if not set.
+
 - **Primary Colors:**
     - `--color-contrast`: Contrast color (typically used for text on colored backgrounds).
     - `--color-green`: Default green color.
@@ -1261,10 +1269,24 @@ Declare your overrides in a global stylesheet — they take effect across all co
 
 ```css
 :root {
-    /* Element Heights for `size` props */
+    /* Element Heights for `size` props — global fallback for all sized components */
     --size-small: 24px;
     --size-medium: 28px;
     --size-large: 32px;
+
+    /* Optional per-group size overrides (fall back to --size-* if not defined) */
+    /* Form controls: Input, Select, Button, TextArea */
+    --size-control-small: 24px;
+    --size-control-medium: 30px;
+    --size-control-large: 36px;
+    /* Badge */
+    --size-badge-small: 20px;
+    --size-badge-medium: 24px;
+    --size-badge-large: 28px;
+    /* Table row heights */
+    --size-table-small: 32px;
+    --size-table-medium: 40px;
+    --size-table-large: 48px;
 
     /* Primary Colors */
     --color-contrast: #ffffff;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "simple-react-ui-kit",
-    "version": "1.8.2",
+    "version": "1.8.3",
     "description": "A lightweight and flexible UI framework for building responsive React applications with customizable components.",
     "repository": "https://github.com/miksrv/simple-react-ui-kit.git",
     "keywords": [

--- a/src/components/badge/styles.module.sass
+++ b/src/components/badge/styles.module.sass
@@ -8,7 +8,7 @@
     margin: 2px
     box-sizing: border-box
     align-items: center
-    height: var(--size-medium)
+    height: var(--size-badge-medium, var(--size-medium))
     padding: 0 12px
     white-space: nowrap
 
@@ -42,7 +42,7 @@
             opacity: .7
 
     &.small
-        height: var(--size-small)
+        height: var(--size-badge-small, var(--size-small))
         font-size: var(--font-size-small)
         padding: 0 8px
 
@@ -51,8 +51,8 @@
             width: 14px
 
     &.medium
-        height: var(--size-medium)
+        height: var(--size-badge-medium, var(--size-medium))
 
     &.large
-        height: var(--size-large)
+        height: var(--size-badge-large, var(--size-large))
         padding: 0 16px

--- a/src/components/button/styles.module.sass
+++ b/src/components/button/styles.module.sass
@@ -19,7 +19,7 @@
     cursor: pointer
     padding: 6px 10px
     border: 0
-    min-height: var(--size-small)
+    min-height: var(--size-control-small, var(--size-small))
     display: flex
     align-content: center
     justify-content: center
@@ -57,7 +57,7 @@
         background-color: var(--button-default-background-active)
 
     &.small
-        height: var(--size-small)
+        height: var(--size-control-small, var(--size-small))
         font-size: var(--font-size-small)
         padding: 6px 8px
 
@@ -66,11 +66,11 @@
             width: 14px
 
     &.medium
-        height: var(--size-medium)
+        height: var(--size-control-medium, var(--size-medium))
         padding: 6px 10px
 
     &.large
-        height: var(--size-large)
+        height: var(--size-control-large, var(--size-large))
         padding: 6px 16px
 
     &.primary

--- a/src/components/container/Container.tsx
+++ b/src/components/container/Container.tsx
@@ -11,7 +11,7 @@ export const Container = React.forwardRef<HTMLElement, ContainerProps>(
         <section
             {...props}
             ref={ref}
-            className={cn(className, styles.container)}
+            className={cn(styles.container, className)}
         >
             {(header || title || action) && (
                 <div className={styles.header}>

--- a/src/components/input/styles.module.sass
+++ b/src/components/input/styles.module.sass
@@ -70,6 +70,7 @@
             svg
                 width: 16px
                 height: 16px
+                fill: var(--text-color-secondary)
 
             &:hover
                 color: var(--text-color-primary)
@@ -99,19 +100,19 @@
         .formField
             .input
                 font-size: var(--font-size-small)
-                height: var(--size-small)
+                height: var(--size-control-small, var(--size-small))
                 padding: 0 8px
 
     &.medium
         .formField
             .input
-                height: var(--size-medium)
+                height: var(--size-control-medium, var(--size-medium))
                 padding: 0 12px
 
     &.large
         .formField
             .input
-                height: var(--size-large)
+                height: var(--size-control-large, var(--size-large))
                 padding: 0 16px
 
     &.disabled

--- a/src/components/select/styles.module.sass
+++ b/src/components/select/styles.module.sass
@@ -135,7 +135,7 @@ $iconSize: 18px
                 border-color: var(--color-red)
 
         &.small
-            min-height: var(--size-small)
+            min-height: var(--size-control-small, var(--size-small))
             font-size: var(--font-size-small)
 
             svg
@@ -143,10 +143,10 @@ $iconSize: 18px
                 width: 14px
 
         &.medium
-            min-height: var(--size-medium)
+            min-height: var(--size-control-medium, var(--size-medium))
 
         &.large
-            min-height: var(--size-large)
+            min-height: var(--size-control-large, var(--size-large))
 
     &.disabled
         *

--- a/src/components/table/styles.module.sass
+++ b/src/components/table/styles.module.sass
@@ -34,31 +34,31 @@
 
         &.small
             th, td
-                height: var(--size-small)
+                height: var(--size-table-small, var(--size-small))
                 font-size: var(--font-size-small)
                 padding: 4px 10px
 
             th
-                height: var(--size-medium)
+                height: var(--size-table-medium, var(--size-medium))
 
 
         &.medium
             th, td
-                height: var(--size-medium)
+                height: var(--size-table-medium, var(--size-medium))
                 font-size: var(--font-size)
                 padding: 4px 12px
 
             th
-                height: var(--size-medium)
+                height: var(--size-table-medium, var(--size-medium))
 
         &.large
             th, td
-                height: var(--size-large)
+                height: var(--size-table-large, var(--size-large))
                 font-size: var(--font-size)
                 padding: 6px 16px
 
             th
-                height: var(--size-large)
+                height: var(--size-table-large, var(--size-large))
 
         td
             padding: 2px 12px

--- a/src/components/textarea/styles.module.sass
+++ b/src/components/textarea/styles.module.sass
@@ -66,19 +66,19 @@
         .formField
             .textarea
                 font-size: var(--font-size-small)
-                min-height: var(--size-small)
+                min-height: var(--size-control-small, var(--size-small))
                 padding: 6px 8px
 
     &.medium
         .formField
             .textarea
-                min-height: var(--size-medium)
+                min-height: var(--size-control-medium, var(--size-medium))
                 padding: 8px 12px
 
     &.large
         .formField
             .textarea
-                min-height: var(--size-large)
+                min-height: var(--size-control-large, var(--size-large))
                 padding: 10px 16px
 
     &.disabled

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,23 @@
     --size-medium: 34px;
     --size-large: 38px;
 
+    /* Optional per-group size overrides (fallback to --size-* if not set) */
+    /* --size-control-small / --size-control-medium / --size-control-large  → input, select, button, textarea */
+    /* --size-badge-small   / --size-badge-medium   / --size-badge-large    → badge */
+    /* --size-table-small   / --size-table-medium   / --size-table-large    → table rows */
+    /* Form controls: Input, Select, Button, TextArea */
+    --size-control-small: 24px;
+    --size-control-medium: 30px;
+    --size-control-large: 36px;
+    /* Badge */
+    --size-badge-small: 20px;
+    --size-badge-medium: 24px;
+    --size-badge-large: 28px;
+    /* Table row heights */
+    --size-table-small: 32px;
+    --size-table-medium: 40px;
+    --size-table-large: 48px;
+
     /* Primary Colors */
     --color-contrast: #ffffff;
 


### PR DESCRIPTION
Introduce per-group sizing CSS custom properties (--size-control-*, --size-badge-*, --size-table-*) with fallbacks to the existing --size-* variables. Update README and global.css to document and provide example defaults for these new variables. Modify component styles (Badge, Button, Input, Select, Table, TextArea) to use the group-specific vars with fallbacks to preserve existing behavior. Also swap className order in Container.tsx to apply base container styles before user classes, and set input SVG fill to --text-color-secondary.