### PR TITLE
Add autocomplete mode to Select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.8.4
+
+### Patch Changes
+
+- Add autocomplete mode to Select component
+
 ## 1.8.3
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -971,6 +971,69 @@ In this example:
 - The selected value is managed in React state.
 - For more details and live examples, check out the Storybook Documentation.
 
+#### Autocomplete Mode
+
+When `options` is initially empty and `onSearch` is provided, the component operates in **autocomplete mode**: the toggle arrow and dropdown are automatically hidden until the user types something. As soon as the user enters text, `onSearch` fires — the parent fetches matching options asynchronously and passes them back via the `options` prop. Once options arrive, the dropdown opens normally. If the search yields no matches, the `notFoundCaption` is shown (which is the intended UX for an explicit search with no results).
+
+This behaviour requires no extra props — it is automatic whenever `options.length === 0` and the search field is empty.
+
+```tsx
+import React, { useState } from 'react'
+import { Select, SelectOptionType } from 'simple-react-ui-kit'
+
+const allOptions: Array<SelectOptionType<number>> = [
+    { key: 1, value: 'Apple' },
+    { key: 2, value: 'Banana' },
+    { key: 3, value: 'Cherry' },
+    { key: 4, value: 'Date' },
+    { key: 5, value: 'Elderberry' }
+]
+
+const AutocompleteExample = () => {
+    const [search, setSearch] = useState<string>('')
+    const [loading, setLoading] = useState(false)
+    const [selected, setSelected] = useState<number | undefined>()
+
+    const filteredOptions = search
+        ? allOptions.filter((o) => o.value.toLowerCase().includes(search.toLowerCase()))
+        : []
+
+    const handleSearch = (text?: string) => {
+        if (!!text?.length) {
+            setSearch(text)
+        }
+
+        setLoading(true)
+        setTimeout(() => {
+            setLoading(false)
+        }, 500)
+    }
+
+    const handleSelect = (selection: Array<SelectOptionType<number>> | undefined) => {
+        const key = selection?.[0]?.key
+        setSelected(key)
+        if (!key) {
+            setSearch('')
+        }
+    }
+
+    return (
+        <Select
+            options={filteredOptions}
+            value={selected}
+            loading={loading}
+            searchable
+            notFoundCaption='No results found'
+            placeholder='Start typing to search...'
+            onSearch={handleSearch}
+            onSelect={handleSelect}
+        />
+    )
+}
+
+export default AutocompleteExample
+```
+
 </details>
 
 ### Skeleton

--- a/README.md
+++ b/README.md
@@ -994,9 +994,7 @@ const AutocompleteExample = () => {
     const [loading, setLoading] = useState(false)
     const [selected, setSelected] = useState<number | undefined>()
 
-    const filteredOptions = search
-        ? allOptions.filter((o) => o.value.toLowerCase().includes(search.toLowerCase()))
-        : []
+    const filteredOptions = search ? allOptions.filter((o) => o.value.toLowerCase().includes(search.toLowerCase())) : []
 
     const handleSearch = (text?: string) => {
         if (!!text?.length) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "simple-react-ui-kit",
-    "version": "1.8.3",
+    "version": "1.8.4",
     "description": "A lightweight and flexible UI framework for building responsive React applications with customizable components.",
     "repository": "https://github.com/miksrv/simple-react-ui-kit.git",
     "keywords": [

--- a/src/components/select/Select.test.tsx
+++ b/src/components/select/Select.test.tsx
@@ -1009,6 +1009,72 @@ describe('Select Component', () => {
         removeSpy.mockRestore()
     })
 
+    // === Autocomplete mode (options=[] + onSearch) ===
+
+    it('does not render toggle button when options is empty and search is empty', () => {
+        render(
+            <Select
+                options={[]}
+                searchable
+            />
+        )
+        expect(screen.queryByRole('button', { name: /open dropdown/i })).not.toBeInTheDocument()
+    })
+
+    it('does not open dropdown when options is empty and user has not typed', () => {
+        render(
+            <Select
+                options={[]}
+                searchable
+            />
+        )
+        fireEvent.click(screen.getByRole('combobox'))
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    })
+
+    it('does not open dropdown on ArrowDown when options is empty and search is empty', () => {
+        render(
+            <Select
+                options={[]}
+                searchable
+            />
+        )
+        const input = screen.getByRole('textbox')
+        fireEvent.keyDown(input, { key: 'ArrowDown' })
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    })
+
+    it('shows toggle button and opens dropdown when options become non-empty', () => {
+        render(
+            <Select
+                options={options}
+                searchable
+            />
+        )
+        expect(screen.getByRole('button', { name: /open dropdown/i })).toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: /open dropdown/i }))
+        expect(screen.getByRole('listbox')).toBeInTheDocument()
+    })
+
+    it('shows dropdown with notFoundCaption when options is empty but user has typed', async () => {
+        const onSearch = jest.fn()
+        render(
+            <Select
+                options={[]}
+                searchable
+                onSearch={onSearch}
+                notFoundCaption='No results found'
+            />
+        )
+        const input = screen.getByRole('textbox')
+        fireEvent.change(input, { target: { value: 'xyz' } })
+
+        await waitFor(() => {
+            expect(screen.getByText('No results found')).toBeInTheDocument()
+        })
+        expect(onSearch).toHaveBeenCalledWith('xyz')
+    })
+
     // PERF-02: portalStyle is set (not display:none) when dropdown is open
     it('sets portal position style when dropdown opens', () => {
         render(<Select options={options} />)

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -130,16 +130,23 @@ export const Select = <T,>({
         [filteredOptions]
     )
 
+    // True when options list is empty and no search text has been entered.
+    // Used to hide the toggle arrow and block dropdown opening in autocomplete mode.
+    const isEmpty = options.length === 0 && !search
+
     // Handle dropdown toggle
     const toggleDropdown = useCallback(() => {
         if (disabled) {
+            return
+        }
+        if (!isOpen && isEmpty) {
             return
         }
         if (!isOpen) {
             onOpen?.()
         }
         setIsOpen(!isOpen)
-    }, [disabled, isOpen, onOpen])
+    }, [disabled, isOpen, isEmpty, onOpen])
 
     const handleSelect = useCallback(
         (option?: SelectOptionType<T>) => {
@@ -223,6 +230,9 @@ export const Select = <T,>({
             if (e.key === 'ArrowDown') {
                 e.preventDefault()
                 if (!isOpen) {
+                    if (isEmpty) {
+                        return
+                    }
                     setIsOpen(true)
                     setHighlightedIndex(getNextIndex(-1, 1))
                     return
@@ -265,6 +275,7 @@ export const Select = <T,>({
             handleSelect,
             handleRemove,
             isOpen,
+            isEmpty,
             multiple,
             onSelect,
             getNextIndex
@@ -287,7 +298,7 @@ export const Select = <T,>({
             }
             if (e.key === 'ArrowDown') {
                 e.preventDefault()
-                if (disabled) {
+                if (disabled || isEmpty) {
                     return
                 }
                 if (!isOpen) {
@@ -306,7 +317,7 @@ export const Select = <T,>({
                 setHighlightedIndex((prev) => getNextIndex(prev, -1))
             }
         },
-        [toggleDropdown, isOpen, highlightedIndex, filteredOptions, handleSelect, disabled, onOpen, getNextIndex]
+        [toggleDropdown, isOpen, highlightedIndex, filteredOptions, handleSelect, disabled, isEmpty, onOpen, getNextIndex]
     )
 
     // Close dropdown on outside click
@@ -492,7 +503,7 @@ export const Select = <T,>({
                             >
                                 <Icon name='Close' />
                             </button>
-                        ) : (
+                        ) : isEmpty ? null : (
                             <button
                                 type='button'
                                 tabIndex={0}

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -317,7 +317,17 @@ export const Select = <T,>({
                 setHighlightedIndex((prev) => getNextIndex(prev, -1))
             }
         },
-        [toggleDropdown, isOpen, highlightedIndex, filteredOptions, handleSelect, disabled, isEmpty, onOpen, getNextIndex]
+        [
+            toggleDropdown,
+            isOpen,
+            highlightedIndex,
+            filteredOptions,
+            handleSelect,
+            disabled,
+            isEmpty,
+            onOpen,
+            getNextIndex
+        ]
     )
 
     // Close dropdown on outside click

--- a/storybook/stories/Select.stories.tsx
+++ b/storybook/stories/Select.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-import { Meta, StoryObj } from '@storybook/react'
+import { Meta, StoryFn, StoryObj } from '@storybook/react'
 
 import { Select, type SelectOptionType, SelectProps } from '../../src'
 
@@ -309,5 +309,70 @@ export const Clearable: StoryObj<typeof meta> = {
         value: 'ru',
         placeholder: 'Select a country',
         label: 'Clearable (with pre-selected value)'
+    }
+}
+
+export const Autocomplete: StoryFn<SelectProps<number>> = (args) => {
+    const [search, setSearch] = useState<string>('')
+    const [loading, setLoading] = useState(false)
+    const [selected, setSelected] = useState<number | undefined>(undefined)
+
+    const allOptions: Array<SelectOptionType<number>> = [
+        { key: 1, value: 'Apple' },
+        { key: 2, value: 'Banana' },
+        { key: 3, value: 'Cherry' },
+        { key: 4, value: 'Date' },
+        { key: 5, value: 'Elderberry' }
+    ]
+
+    const filteredOptions = search ? allOptions.filter((o) => o.value.toLowerCase().includes(search.toLowerCase())) : []
+
+    const handleSearch = (text?: string) => {
+        if (!!text?.length) {
+            setSearch(text)
+        }
+
+        setLoading(true)
+        setTimeout(() => {
+            setLoading(false)
+        }, 500)
+    }
+
+    const handleSelect = (selection: Array<SelectOptionType<number>> | undefined) => {
+        const key = selection?.[0]?.key
+        setSelected(key)
+        if (!key) {
+            setSearch('')
+        }
+    }
+
+    return (
+        <>
+            <Select
+                {...args}
+                options={filteredOptions}
+                loading={loading}
+                value={selected}
+                onSearch={handleSearch}
+                onSelect={handleSelect}
+            />
+        </>
+    )
+}
+
+Autocomplete.args = {
+    placeholder: 'Start typing to search...',
+    searchable: true,
+    notFoundCaption: 'No results found'
+}
+
+Autocomplete.parameters = {
+    docs: {
+        description: {
+            story:
+                'Demonstrates autocomplete mode: `options` starts empty and is populated asynchronously via `onSearch`. ' +
+                'The toggle arrow and dropdown are hidden until the user types. ' +
+                'Once text is entered, `onSearch` fires, options load after 500ms, and the dropdown opens automatically.'
+        }
     }
 }


### PR DESCRIPTION
Implement autocomplete behavior for Select when options are initially empty and onSearch is provided. Key changes:

- src/components/select/Select.tsx: introduce isEmpty check to hide the toggle arrow and block opening the dropdown until the user types; update keyboard and click handlers to respect this mode and avoid opening the list when there are no options and no search text.
- src/components/select/Select.test.tsx: add unit tests covering autocomplete scenarios (no toggle when empty, blocking ArrowDown/click opens, showing notFoundCaption when user types and no results, and opening when options become non-empty).
- storybook/stories/Select.stories.tsx: add an Autocomplete story demonstrating async search, filtered options, loading state, and notFoundCaption.
- README.md: document Autocomplete Mode with usage example and explanation of automatic behavior when options.length === 0 and the search field is empty.

These changes enable a UX where the Select acts as an async autocomplete: the dropdown and toggle are hidden until the user enters search text, onSearch is fired, and results populate the options prop which then allows normal dropdown behavior.